### PR TITLE
Move list extension tests into their own test file

### DIFF
--- a/tests/LibraryTests.elm
+++ b/tests/LibraryTests.elm
@@ -11,100 +11,27 @@ import Card exposing (..)
 library : Test
 library =
     describe "Library module"
-        [ removingACard
-        , addingACard
+        [ removingByName
         ]
 
 
-removingACard : Test
-removingACard =
-    describe "removing a card"
-        [ describe "from the top"
-            [ test "non-empty library" <|
-                \() ->
-                    let
-                        library =
-                            [ Card "a", Card "b", Card "c" ]
-                    in
-                        Expect.equal ( Just (Card "a"), [ Card "b", Card "c" ] ) <|
-                            popTop library
-            , test "empty library" <|
-                \() ->
-                    Expect.equal ( Nothing, [] ) <| popTop []
-            ]
-        , describe "by name" <|
-            [ test "card is present" <|
-                \() ->
-                    let
-                        library =
-                            [ Card "a", Card "b", Card "c" ]
-                    in
-                        Expect.equal ( Just (Card "b"), [ Card "a", Card "c" ] ) <|
-                            removeByName "b" library
-            , test "card is not present" <|
-                \() ->
-                    let
-                        library =
-                            [ Card "a", Card "b" ]
-                    in
-                        Expect.equal ( Nothing, [ Card "a", Card "b" ] ) <|
-                            removeByName "c" library
-            ]
-        , describe "from the bottom" <|
-            [ test "non-empty library" <|
-                \() ->
-                    let
-                        library =
-                            [ Card "a", Card "b", Card "c" ]
-                    in
-                        Expect.equal ( Just (Card "c"), [ Card "a", Card "b" ] ) <|
-                            popBottom library
-            , test "empty library" <|
-                \() ->
-                    Expect.equal ( Nothing, [] ) <| popBottom []
-            ]
-        ]
-
-
-addingACard : Test
-addingACard =
-    describe "adding a card"
-        [ test "to the top" <|
+removingByName : Test
+removingByName =
+    describe "removing a card by name"
+        [ test "card is present" <|
             \() ->
                 let
                     library =
                         [ Card "a", Card "b", Card "c" ]
                 in
-                    Expect.equal (Card "d" :: library) <|
-                        pushTop (Card "d") library
-        , test "to the bottom" <|
+                    Expect.equal ( Just (Card "b"), [ Card "a", Card "c" ] ) <|
+                        removeByName "b" library
+        , test "card is not present" <|
             \() ->
                 let
                     library =
-                        [ Card "a", Card "b", Card "c" ]
+                        [ Card "a", Card "b" ]
                 in
-                    Expect.equal (library ++ [ Card "d" ]) <|
-                        pushBottom (Card "d") library
-        ]
-
-
-shuffling : Test
-shuffling =
-    describe "shuffle the library"
-        [ test "non-empty library" <|
-            \() ->
-                let
-                    initial =
-                        Library.Model.init [ "a", "b", "c" ]
-
-                    newOrder =
-                        [ 3, 1, 2 ]
-
-                    expected =
-                        Library.Model.init [ "c", "a", "b" ]
-                in
-                    Expect.equal expected <| shuffle initial newOrder
-        , test "empty library" <|
-            \() ->
-                Expect.equal [] <| shuffle [] []
+                    Expect.equal ( Nothing, [ Card "a", Card "b" ] ) <|
+                        removeByName "c" library
         ]

--- a/tests/ListExtensionTests.elm
+++ b/tests/ListExtensionTests.elm
@@ -1,0 +1,88 @@
+module ListExtensionTests exposing (..)
+
+import Test exposing (..)
+import Expect
+import Data.List.Extensions exposing (..)
+
+
+listExtensions : Test
+listExtensions =
+    describe "List extensions"
+        [ adding 
+        , removing
+        , shuffling
+        ]
+
+
+adding : Test
+adding =
+    describe "add an element to the list"
+        [ test "to the top" <|
+            \() ->
+                let
+                    list =
+                        [ "a",  "b" ]
+                in
+                    Expect.equal [ "c", "a", "b" ] <|
+                        pushTop "c" list
+        , test "to the bottom" <|
+            \() ->
+                let
+                    list = [ "a", "b" ]
+                in
+                    Expect.equal [ "a", "b", "c" ] <|
+                        pushBottom "c" list
+        ]
+
+
+removing : Test
+removing =
+    describe "removing an element from the list"
+        [ describe "from the top"
+            [ test "non-empty list" <|
+                \() ->
+                    let
+                        list =
+                            [ "a", "b", "c" ]
+                    in
+                        Expect.equal ( Just "a", [ "b", "c" ] ) <|
+                            popTop list
+            , test "empty list" <|
+                \() ->
+                    Expect.equal ( Nothing, [] ) <| popTop []
+            ]
+        , describe "from the bottom" <|
+            [ test "non-empty library" <|
+                \() ->
+                    let
+                        list =
+                            [ "a", "b", "c" ]
+                    in
+                        Expect.equal ( Just "c", [ "a", "b" ] ) <|
+                            popBottom list
+            , test "empty library" <|
+                \() ->
+                    Expect.equal ( Nothing, [] ) <| popBottom []
+            ]
+        ]
+
+shuffling : Test
+shuffling =
+    describe "shuffle the list"
+        [ test "non-empty list" <|
+            \() ->
+                let
+                    initial =
+                        [ "a", "b", "c" ]
+
+                    newOrder =
+                        [ 3, 1, 2 ]
+
+                    expected =
+                        [ "b", "c", "a" ]
+                in
+                    Expect.equal expected <| shuffle initial newOrder
+        , test "empty list" <|
+            \() ->
+                Expect.equal [] <| shuffle [] []
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -7,8 +7,9 @@ import String
 import LibraryTests exposing (..)
 import HandTests exposing (..)
 import ActionsTests exposing (..)
+import ListExtensionTests exposing (..)
 
 
 all : Test
 all =
-    Test.concat [ library, hand, cardMovement ]
+    Test.concat [ library, hand, cardMovement, listExtensions ]


### PR DESCRIPTION
This finishes up the refactor of utility functions. We extracted the functions which used to be specifically typed and lived in the library module into their own module, so this PR adds a dedicated test file for them.